### PR TITLE
fix(Providing jQuery to immediate scope to avoid prototype collisions)

### DIFF
--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -11,7 +11,7 @@
  *  Originally forked from https://github.com/leongersen/noUiSlider
  *
  */
-(function () {
+(function ($) {
     'use strict';
 
     /**
@@ -417,4 +417,4 @@
             }
         };
     });
-}());
+}(window.jQuery));


### PR DESCRIPTION
When using the angular-rangeslider directive on a page that uses $ for another purpose, there will be an error when checking for specific functions on $, such as bind.  By providing jQuery to the immediate function, we are assured that $ will always be jQuery.
