### PR TITLE
Added a call to requestAnimationFrame for better performance

### DIFF
--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -342,7 +342,7 @@
                             scope.filteredModelMax = scope.modelMax;
                         }
 
-                        requestAnimationFrame(updateUI);
+                        requestAnimFrame(updateUI);
                     }
 
                 }
@@ -564,4 +564,16 @@
             }
         };
     });
+    
+    // requestAnimationFramePolyFill
+    // http://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
+    // shim layer with setTimeout fallback
+    window.requestAnimFrame = (function(){
+      return  window.requestAnimationFrame       ||
+          window.webkitRequestAnimationFrame ||
+          window.mozRequestAnimationFrame    ||
+          function( callback ){
+            window.setTimeout(callback, 1000 / 60);
+          };
+    })();
 }());


### PR DESCRIPTION
I was testing this slider on my iPhone 4. It was pretty horrible. I made minor changes so that new frames aren't calculated and drawn when there is another frame pending to be drawn. It's slightly better.
I also removed some redundant calls to angular.element().
I can think of some more optimizations but I thought I wouldn't change too much in a single pull request.
