### PR TITLE
Updated bower.json to include the css file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "angular-rangeslider",
   "version": "0.0.7",
-  "main": "./angular.rangeSlider.js",
+  "main": [
+    "./angular.rangeSlider.js",
+    "./angular.rangeSlider.css"
+  ],
   "dependencies": {
     "jquery": ">=1.7",
     "angular": ">=1.2.*"


### PR DESCRIPTION
The missing css in the main entry causes the stylesheet not to be included in the build, when using wiredep or other similar build tools.
