### PR TITLE
I have

### DIFF
--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -544,11 +544,11 @@
                                         if (index === 0) {
 
                                             // update model as we slide
-                                            scope.modelMin = parseFloat((((proposal * range) / 100) + scope.min)).toFixed(scope.decimalPlaces);
+                                            scope.modelMin = parseFloat((((proposal * range) / 100) + parseInt(scope.min))).toFixed(scope.decimalPlaces);
 
                                         } else if (index === 1) {
 
-                                            scope.modelMax = parseFloat((((proposal * range) / 100) + scope.min)).toFixed(scope.decimalPlaces);
+                                            scope.modelMax = parseFloat((((proposal * range) / 100) + parseInt(scope.min))).toFixed(scope.decimalPlaces);
                                         }
 
                                         // update angular


### PR DESCRIPTION
<div  range-slider show-values="true"  min="refinement.children[0].name" max="refinement.children[refinement.children.length-1].name" model-min="vm.selPubYearRange.min" model-max="vm.selPubYearRange.max" ></div>


refinement.children[0].name is considered a string not a number and hence

scope.modelMin = parseFloat((((proposal \* range) / 100) + (scope.min)).toFixed(scope.decimalPlaces);
is concatinating the values "parseFloat((((proposal \* range) / 100)" and "(scope.min)" instead of adding them

so changed it scope.min to int before adding.
