### PR TITLE
"filter" attribute can be used in standard angular notation

### DIFF
--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -1,13 +1,13 @@
 /*
  *  Angular RangeSlider Directive
- * 
+ *
  *  Version: 0.0.11
  *
  *  Author: Daniel Crisp, danielcrisp.com
  *
  *  The rangeSlider has been styled to match the default styling
  *  of form elements styled using Twitter's Bootstrap
- * 
+ *
  *  Originally forked from https://github.com/leongersen/noUiSlider
  *
 
@@ -119,12 +119,11 @@
                     modelMin: '=?',
                     modelMax: '=?',
                     onHandleDown: '&', // calls optional function when handle is grabbed
-                    onHandleUp: '&', // calls optional function when handle is released 
+                    onHandleUp: '&', // calls optional function when handle is released
                     orientation: '@', // options: horizontal | vertical | vertical left | vertical right
                     step: '@',
                     decimalPlaces: '@',
                     filter: '@',
-                    filterOptions: '@',
                     showValues: '@',
                     pinHandle: '@',
                     preventEqualMinMax: '@',
@@ -164,7 +163,7 @@
                 scope: scopeOptions,
                 link: function(scope, element, attrs, controller) {
 
-                    /** 
+                    /**
                      *  FIND ELEMENTS
                      */
 
@@ -386,8 +385,27 @@
                             scope.modelMax = Math.min(scope.max, scope.modelMax);
 
                             if (scope.filter) {
-                                scope.filteredModelMin = $filter(scope.filter)(scope.modelMin, scope.filterOptions);
-                                scope.filteredModelMax = $filter(scope.filter)(scope.modelMax, scope.filterOptions);
+                                var filterTokens = scope.filter.split(':'),
+                                    filterName = scope.filter.split(':')[0],
+                                    filterOptions = filterTokens.slice().slice(1),
+                                    modelMinOptions,
+                                    modelMaxOptions;
+
+                                // properly parse string and number args
+                                filterOptions = filterOptions.map(function (arg) {
+                                    if (isNumber(arg)) {
+                                        return +arg;
+                                    } else if ((arg[0] == "\"" && arg[arg.length-1] == "\"") || (arg[0] == "\'" && arg[arg.length-1] == "\'")) {
+                                        return arg.slice(1, -1);
+                                    }
+                                });
+                                modelMinOptions = filterOptions.slice();
+                                modelMaxOptions = filterOptions.slice();
+                                modelMinOptions.unshift(scope.modelMin);
+                                modelMaxOptions.unshift(scope.modelMax);
+
+                                scope.filteredModelMin = $filter(filterName).apply(null, modelMinOptions);
+                                scope.filteredModelMax = $filter(filterName).apply(null, modelMaxOptions);
                             } else {
                                 scope.filteredModelMin = scope.modelMin;
                                 scope.filteredModelMax = scope.modelMax;

--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -124,6 +124,7 @@
                     step: '@',
                     decimalPlaces: '@',
                     filter: '@',
+                    filterOptions: '@',
                     showValues: '@',
                     pinHandle: '@',
                     preventEqualMinMax: '@',
@@ -384,7 +385,10 @@
                             scope.modelMin = Math.max(scope.min, scope.modelMin);
                             scope.modelMax = Math.min(scope.max, scope.modelMax);
 
-                            if (scope.filter) {
+                            if (scope.filterOptions) {
+                                scope.filteredModelMin = $filter(scope.filter)(scope.modelMin, scope.filterOptions);
+                                scope.filteredModelMax = $filter(scope.filter)(scope.modelMax, scope.filterOptions);
+                            } else if (scope.filter) {
                                 var filterTokens = scope.filter.split(':'),
                                     filterName = scope.filter.split(':')[0],
                                     filterOptions = filterTokens.slice().slice(1),


### PR DESCRIPTION
This allows using filters with more than one option.
Usage example: 

    <div range-slider min=0, max=100000, filter="currency:'$':0"></div>

Works with either single or double quotes (e.g.: `filter='currency:"$":0' `) and it's backwards compatible.