### PR TITLE
gracefully handle deleting modelMax through input

### DIFF
--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -368,7 +368,18 @@
                                 if (scope.pinHandle !== 'max') {
                                     throwWarning('modelMax must be a number');
                                 }
-                                scope.modelMax = scope.max;
+                                // scope.modelMax = scope.max;
+                                
+                                // if deleted with backspace in a type="number" input, the value is set to null
+                                if (scope.modelMax === null) {
+                                    if (scope.modelMin) {
+                                        scope.modelMax = scope.modelMin
+                                    } else if (scope.min) {
+                                        scope.modelMax = scope.min;
+                                    } else {
+                                        scope.modelMax = 0;
+                                    }
+                                }
                             }
 
                             var handle1pos = restrict(((scope.modelMin - scope.min) / range) * 100),


### PR DESCRIPTION
When modelMax is deleted, e.g. by a user pushing backspace when focused on an input field which has ng-model set to modelMin or modelMax, then modelMax is are set to 0 or modelMin.

This fixes the issue that happens when trying to delete the last cipher from an input field - the value just resets to max.