### PR TITLE
Removed jQuery dependency

### DIFF
--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -147,6 +147,10 @@
             // }
 
 
+            var findByClassName = function(element, className) {
+                return angular.element(element[0].getElementsByClassName(className));
+            };
+
             return {
                 restrict: 'A',
                 replace: true,
@@ -170,9 +174,9 @@
                      */
 
                     var $slider = angular.element(element),
-                        handles = [element.find('.ngrs-handle-min'), element.find('.ngrs-handle-max')],
-                        values = [element.find('.ngrs-value-min'), element.find('.ngrs-value-max')],
-                        join = element.find('.ngrs-join'),
+                        handles = [findByClassName(element, 'ngrs-handle-min'), findByClassName(element, 'ngrs-handle-max')],
+                        values = [findByClassName(element, 'ngrs-value-min'), findByClassName(element, 'ngrs-value-max')],
+                        join = findByClassName(element, 'ngrs-join'),
                         pos = 'left',
                         posOpp = 'right',
                         orientation = 0,
@@ -279,7 +283,7 @@
                                 // flag as true
                                 scope.attachHandleValues = true;
                                 // add class to runner
-                                element.find('.ngrs-value-runner').addClass('ngrs-attached-handles');
+                                findByClassName(element, 'ngrs-value-runner').addClass('ngrs-attached-handles');
                             } else {
                                 scope.attachHandleValues = false;
                             }
@@ -487,6 +491,7 @@
                     function handleMove(index) {
 
                         var $handle = handles[index];
+                        var $body = angular.element($document).find('body');
 
                         // on mousedown / touchstart
                         $handle.bind(onEvent + 'X', function(event) {
@@ -504,7 +509,7 @@
                             }
 
                             // stop user accidentally selecting stuff
-                            angular.element('body').bind('selectstart' + eventNamespace, function() {
+                            $body.bind('selectstart' + eventNamespace, function() {
                                 return false;
                             });
 
@@ -520,7 +525,7 @@
                                 $slider.addClass('ngrs-focus ' + handleDownClass);
 
                                 // add touch class for MS styling
-                                angular.element('body').addClass('ngrs-touching');
+                                $body.addClass('ngrs-touching');
 
                                 // listen for mousemove / touchmove document events
                                 $document.bind(moveEvent, function(e) {
@@ -546,9 +551,8 @@
                                     movement = [
                                         (previousClick[0] !== currentClick[0]), (previousClick[1] !== currentClick[1])
                                     ];
-
                                     // propose a movement
-                                    proposal = originalPosition + ((currentClick[orientation] * 100) / (orientation ? $slider.height() : $slider.width()));
+                                    proposal = originalPosition + ((currentClick[orientation] * 100) / (orientation ? $slider[0].offsetHeight : $slider[0].offsetWidth));
 
                                     // normalize so it can't move out of bounds
                                     proposal = restrict(proposal);
@@ -617,7 +621,7 @@
                                     $document.off(moveEvent);
                                     $document.off(offEvent);
 
-                                    angular.element('body').removeClass('ngrs-touching');
+                                    $body.removeClass('ngrs-touching');
 
                                     // cancel down flag
                                     down = false;

--- a/angular.rangeSlider.js
+++ b/angular.rangeSlider.js
@@ -145,11 +145,22 @@
             // } else {
             //     angular.element('html').addClass('ngrs-no-touch');
             // }
-
-
-            var findByClassName = function(element, className) {
-                return angular.element(element[0].getElementsByClassName(className));
+            var filter = function(array, method) {
+                var filteredArray = [];
+                for (var i=0; i<array.length; i++) {
+                    if (method(array[i])) {
+                        filteredArray.push(array[i])
+                    }
+                }
+                return filteredArray;
             };
+
+            var findDivByClassName = function(element, className) {
+                return angular.element(filter(element.find('div'), function(el){
+                    return angular.element(el).hasClass(className);
+                }));
+            };
+
 
             return {
                 restrict: 'A',
@@ -174,9 +185,9 @@
                      */
 
                     var $slider = angular.element(element),
-                        handles = [findByClassName(element, 'ngrs-handle-min'), findByClassName(element, 'ngrs-handle-max')],
-                        values = [findByClassName(element, 'ngrs-value-min'), findByClassName(element, 'ngrs-value-max')],
-                        join = findByClassName(element, 'ngrs-join'),
+                        handles = [findDivByClassName(element, 'ngrs-handle-min'), findDivByClassName(element, 'ngrs-handle-max')],
+                        values = [findDivByClassName(element, 'ngrs-value-min'), findDivByClassName(element, 'ngrs-value-max')],
+                        join = findDivByClassName(element, 'ngrs-join'),
                         pos = 'left',
                         posOpp = 'right',
                         orientation = 0,
@@ -283,7 +294,7 @@
                                 // flag as true
                                 scope.attachHandleValues = true;
                                 // add class to runner
-                                findByClassName(element, 'ngrs-value-runner').addClass('ngrs-attached-handles');
+                                findDivByClassName(element, 'ngrs-value-runner').addClass('ngrs-attached-handles');
                             } else {
                                 scope.attachHandleValues = false;
                             }

--- a/demo/index.html
+++ b/demo/index.html
@@ -305,8 +305,8 @@ $scope.demo9 = {
 
 	</div>
 
-	<!-- we need jQuery -->
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js"></script>
+	<!-- we don't need jQuery anymore -->
+	<!-- <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js"></script> -->
 	<!-- and Angular, of course -->
 	<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.15/angular.js"></script>
 	<!-- and out directive code -->


### PR DESCRIPTION
I can see there is another pull request on the same topic: https://github.com/danielcrisp/angular-rangeslider/pull/21

Changes here are really small:

- Changed the `element.find(className)` to `findDivByClassName = function(element, className)`
- Changed `angular.element('body')` to `angular.element($document).find('body')`
- Changed `$slider.width()` to `$slider[0].offsetWidth` (and same with height)

I tested it in Chrome and FF and it works. I can't test it under IE because I'm using Linux. But `offsetWidth` is [IE compatible](http://www.w3schools.com/jsref/prop_element_offsetwidth.asp).

Regarding `findDivByClassName`, I first used `getElementsByClassName` but it appeard [not to be IE8 compatible](http://www.w3schools.com/jsref/met_document_getelementsbyclassname.asp) so I went for a custom method, that only uses `angular.find(tagName)` which must be based on `getElementsByTagName` which [is IE8 compatible](http://www.w3schools.com/jsref/met_document_getelementsbytagname.asp).

Here it is:

```
            var filter = function(array, method) {
                var filteredArray = [];
                for (var i=0; i<array.length; i++) {
                    if (method(array[i])) {
                        filteredArray.push(array[i])
                    }
                }
                return filteredArray;
            };

            var findDivByClassName = function(element, className) {
                return angular.element(filter(element.find('div'), function(el){
                    return angular.element(el).hasClass(className);
                }));
            };
```

Hope this gets merged soon! :smile: 